### PR TITLE
Add unit tests for mercury.common.inventory_client.client

### DIFF
--- a/src/mercury-common/mercury/common/inventory_client/client.py
+++ b/src/mercury-common/mercury/common/inventory_client/client.py
@@ -23,19 +23,37 @@ LOG = logging.getLogger(__name__)
 
 
 class InventoryClient(SimpleRouterReqClient):
+    """Client to interact with inventory."""
     @staticmethod
     def raise_reply_error(reply):
-        raise MercuryCritical('Problem talking to inventory service: message = %s, tb = %s' % (
-            reply.get('message'),
-            '\n'.join(reply.get('tb', []))
-        ))
+        """Raise a MercuryCritical exception.
+
+        Called when the client cannot talk to the inventory service.
+        :raises: MercuryCritical.
+        """
+        raise MercuryCritical('Problem talking to inventory service: '
+                              'message = %s, tb = %s' % (
+                                  reply.get('message'),
+                                  '\n'.join(reply.get('tb', []))
+                              ))
 
     def check_and_return(self, reply):
+        """Check a transceiver's reply for errors.
+
+        :param reply: A dictionary containing the transceiver's reply.
+        :returns: The 'response' field of the transceiver's reply.
+        """
         if reply.get('error'):
             self.raise_reply_error(reply)
         return reply['response']
 
     def insert_one(self, device_info):
+        """Insert a new device in inventory.
+
+        :param device_info: A dict containing the new device info.
+        :returns: The 'response' field of the transceiver's reply.
+        :raises: MercuryCritical if 'mercury_id' is missing.
+        """
         mercury_id = device_info.get('mercury_id')
         if not mercury_id:
             raise MercuryCritical('device_info is missing mercury_id')
@@ -47,7 +65,12 @@ class InventoryClient(SimpleRouterReqClient):
         return self.check_and_return(self.transceiver(payload))
 
     def update_one(self, mercury_id, update_data):
+        """Update a device in inventory.
 
+        :param mercury_id: The ID of the device to update.
+        :param update_data: A dict containing the data to update.
+        :returns: The 'response' field of the transceiver's reply.
+        """
         payload = {
             'endpoint': 'update_one',
             'args': [mercury_id],
@@ -57,6 +80,13 @@ class InventoryClient(SimpleRouterReqClient):
         return self.check_and_return(self.transceiver(payload))
 
     def get_one(self, mercury_id, projection=None):
+        """Get a device from inventory.
+
+        :param mercury_id: The ID of the device.
+        :param projection: A dict specifying which fields should be included
+            in the results.
+        :returns: The 'response' field of the transceiver's reply.
+        """
         payload = {
             'endpoint': 'get_one',
             'args': [mercury_id],
@@ -67,6 +97,15 @@ class InventoryClient(SimpleRouterReqClient):
         return self.check_and_return(self.transceiver(payload))
 
     def query(self, query_data, projection=None, limit=0, sort_direction=1):
+        """Query inventory for devices matching query_data.
+
+        :param query_data: A dict to filter the results.
+        :param projection: A dict specifying which fields should be included
+            in the results.
+        :param limit: The maximum number of results to return.
+        :param sort_direction: The sort direction.
+        :returns: The 'response' field of the transceiver's reply.
+        """
         payload = {
             'endpoint': 'query',
             'args': [query_data],
@@ -79,6 +118,11 @@ class InventoryClient(SimpleRouterReqClient):
         return self.check_and_return(self.transceiver(payload))
 
     def delete(self, mercury_id):
+        """Delete a device from inventory.
+
+        :param mercury_id: The ID of the device.
+        :returns: The 'response' field of the transceiver's reply.
+        """
         payload = {
             'endpoint': 'delete',
             'args': [mercury_id]
@@ -86,9 +130,13 @@ class InventoryClient(SimpleRouterReqClient):
         return self.check_and_return(self.transceiver(payload))
 
     def count(self, query_data):
+        """Count how many devices match query_data.
+
+        :param query_data: A dict to filter the results.
+        :returns: The 'response' field of the transceiver's reply.
+        """
         payload = {
             'endpoint': 'count',
             'args': [query_data]
         }
         return self.check_and_return(self.transceiver(payload))
-

--- a/src/mercury-common/tests/unit/inventory_client/test_client.py
+++ b/src/mercury-common/tests/unit/inventory_client/test_client.py
@@ -1,0 +1,167 @@
+# Copyright 2017 Rackspace
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import mock
+
+from mercury.common.exceptions import MercuryCritical
+from mercury.common.inventory_client import client
+from tests.unit.base import MercuryCommonUnitTest
+
+
+class FakeInventoryClient(client.InventoryClient):
+    """Helper class to fake an inventory client in tests."""
+    def __init__(self):
+        self.ctx = None
+        self.socket = None
+
+
+class InventoryClientUnitTest(MercuryCommonUnitTest):
+    """Tests for mercury.common.inventory_client.client.InventoryClient"""
+    def setUp(self):
+        super(InventoryClientUnitTest, self).setUp()
+        self.inventory_client = FakeInventoryClient()
+
+    def test_raise_reply_error(self):
+        """Test raise_reply_error()."""
+        reply = {'message': 'fake_message', 'tb': ['val1', 'val2']}
+        expected_error = ('Problem talking to inventory service: '
+                          'message = fake_message, tb = val1\nval2')
+        self.assertRaisesRegexp(MercuryCritical,
+                                expected_error,
+                                self.inventory_client.raise_reply_error,
+                                reply)
+
+    def test_raise_reply_error_no_traceback(self):
+        """Test raise_reply_error() with no traceback."""
+        reply = {'message': 'fake_message'}
+        expected_error = ('Problem talking to inventory service: '
+                          'message = fake_message, tb = ')
+        self.assertRaisesRegexp(MercuryCritical,
+                                expected_error,
+                                self.inventory_client.raise_reply_error,
+                                reply)
+
+    def test_check_and_return(self):
+        """Test check_and_return()."""
+        reply = {'response': 'fake_response'}
+        response = self.inventory_client.check_and_return(reply)
+        self.assertEqual(reply['response'], response)
+
+    def test_check_and_return_fail(self):
+        """Test check_and_return() with error."""
+        reply = {'error': 'fail'}
+        self.assertRaises(MercuryCritical,
+                          self.inventory_client.check_and_return,
+                          reply)
+
+    @mock.patch('mercury.common.transport.SimpleRouterReqClient.transceiver')
+    def test_insert_one(self, mock_transceiver):
+        """Test insert_one()."""
+        mock_transceiver.return_value = {'response': 'fake_response'}
+
+        device_info = {'mercury_id': 1}
+        payload = {
+            'endpoint': 'insert_one',
+            'args': [device_info]
+        }
+
+        response = self.inventory_client.insert_one(device_info)
+        mock_transceiver.assert_called_once_with(payload)
+        self.assertEqual('fake_response', response)
+
+    def test_insert_one_no_mercury_id(self):
+        """Test insert_one() fails when no mercury_id in device_info."""
+        device_info = {}
+        self.assertRaises(MercuryCritical,
+                          self.inventory_client.insert_one,
+                          device_info)
+
+    @mock.patch('mercury.common.transport.SimpleRouterReqClient.transceiver')
+    def test_update_one(self, mock_transceiver):
+        """Test update_one()."""
+        mock_transceiver.return_value = {'response': 'fake_response'}
+        mercury_id = 1
+        update_data = 'fake_data'
+        payload = {
+            'endpoint': 'update_one',
+            'args': [mercury_id],
+            'kwargs': {'update_data': update_data}
+        }
+
+        response = self.inventory_client.update_one(mercury_id, update_data)
+        mock_transceiver.assert_called_once_with(payload)
+        self.assertEqual('fake_response', response)
+
+    @mock.patch('mercury.common.transport.SimpleRouterReqClient.transceiver')
+    def test_get_one(self, mock_transceiver):
+        """Test get_one()."""
+        mock_transceiver.return_value = {'response': 'fake_response'}
+        mercury_id = 1
+        payload = {
+            'endpoint': 'get_one',
+            'args': [mercury_id],
+            'kwargs': {'projection': None}
+        }
+
+        response = self.inventory_client.get_one(mercury_id)
+        mock_transceiver.assert_called_once_with(payload)
+        self.assertEqual('fake_response', response)
+
+    @mock.patch('mercury.common.transport.SimpleRouterReqClient.transceiver')
+    def test_query(self, mock_transceiver):
+        """Test query()."""
+        mock_transceiver.return_value = {'response': 'fake_response'}
+        query_data = 'fake_data'
+        payload = {
+            'endpoint': 'query',
+            'args': [query_data],
+            'kwargs': {
+                'projection': None,
+                'limit': 0,
+                'sort_direction': 1
+            }
+        }
+
+        response = self.inventory_client.query(query_data)
+        mock_transceiver.assert_called_once_with(payload)
+        self.assertEqual('fake_response', response)
+
+    @mock.patch('mercury.common.transport.SimpleRouterReqClient.transceiver')
+    def test_delete(self, mock_transceiver):
+        """Test delete()."""
+        mock_transceiver.return_value = {'response': 'fake_response'}
+        mercury_id = 1
+        payload = {
+            'endpoint': 'delete',
+            'args': [mercury_id],
+        }
+
+        response = self.inventory_client.delete(mercury_id)
+        mock_transceiver.assert_called_once_with(payload)
+        self.assertEqual('fake_response', response)
+
+    @mock.patch('mercury.common.transport.SimpleRouterReqClient.transceiver')
+    def test_count(self, mock_transceiver):
+        """Test count()."""
+        mock_transceiver.return_value = {'response': 'fake_response'}
+        query_data = 'fake_data'
+        payload = {
+            'endpoint': 'count',
+            'args': [query_data],
+        }
+
+        response = self.inventory_client.count(query_data)
+        mock_transceiver.assert_called_once_with(payload)
+        self.assertEqual('fake_response', response)


### PR DESCRIPTION
```
=============================================== test session starts ================================================
platform linux2 -- Python 2.7.9, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /home/vagrant/Git/mercury/src/mercury-common, inifile:
plugins: cov-2.4.0
collected 36 items

tests/unit/test_configuration.py ...
tests/unit/test_mercury_id.py ......
tests/unit/inventory_client/test_client.py ...........
tests/unit/task_managers/base/test_manager.py .......
tests/unit/task_managers/base/test_task.py ..
tests/unit/task_managers/base/test_worker.py ....
tests/unit/task_managers/redis/test_redis_task.py ...

---------- coverage: platform linux2, python 2.7.9-final-0 -----------
Name                                             Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------
mercury/common/inventory_client/client.py           32      0   100%

============================================ 36 passed in 0.28 seconds =============================================
```