### PR TITLE
Add unit tests for mercury.common.mongo

### DIFF
--- a/src/mercury-common/mercury/common/mongo.py
+++ b/src/mercury-common/mercury/common/mongo.py
@@ -12,6 +12,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+"""Provides MongoDB connection functionalities for Mercury."""
 
 import logging
 import pymongo
@@ -21,6 +22,13 @@ log = logging.getLogger(__name__)
 
 
 def get_connection(server_or_servers=None, replica_set=None):
+    """Creates a new MongoDB client.
+
+    :param server_or_servers: Hostname / MongoDB URI or list of hostnames /
+        URIs for the client to connect to.
+    :param replica_set: The name of the replica set to connect to.
+    :returns: A MongoClient instance.
+    """
     servers = server_or_servers
     if servers is not None:
         if not isinstance(servers, list):
@@ -36,7 +44,15 @@ class MongoCollection(object):
                  collection,
                  server_or_servers=None,
                  replica_set=None):
+        """Get a collection from a Mongo database.
 
+        :param database: The name of the database containing the collection.
+        :param collection: The name of the collection.
+        :param server_or_servers: Hostname / MongoDB URI or list of hostnames /
+            URIs for the client to connect to.
+        :param replica_set: The name of the replica set to connect to.
+        :raises: InvalidName if the database or collection name is invalid.
+        """
         self.servers = server_or_servers
         self.replica_set = replica_set
         self.database_name = database
@@ -50,14 +66,29 @@ class MongoCollection(object):
         self.collection = self.db[self.collection_name]
 
 
-def get_collection(database, collection, connection=None, server_or_servers=None, replica_set=None):
-        database_name = database
-        collection_name = collection
+def get_collection(database,
+                   collection,
+                   connection=None,
+                   server_or_servers=None,
+                   replica_set=None):
+    """Get a collection from a Mongo database.
 
-        if not connection:
-            connection = get_connection(server_or_servers, replica_set)
+    :param database: The name of the database containing the collection.
+    :param collection: The name of the collection.
+    :param connection: A MongoClient instance.
+    :param server_or_servers: Hostname / MongoDB URI or list of hostnames /
+        URIs for the client to connect to.
+    :param replica_set: The name of the replica set to connect to.
+    :returns: A MongoDB collection.
+    :raises: InvalidName if the database or collection name is invalid.
+    """
+    database_name = database
+    collection_name = collection
 
-        log.info('database: %s' % database_name)
-        db = connection[database_name]
-        log.info('collection: %s' % collection_name)
-        return db[collection_name]
+    if not connection:
+        connection = get_connection(server_or_servers, replica_set)
+
+    log.info('database: %s' % database_name)
+    db = connection[database_name]
+    log.info('collection: %s' % collection_name)
+    return db[collection_name]

--- a/src/mercury-common/tests/unit/test_mongo.py
+++ b/src/mercury-common/tests/unit/test_mongo.py
@@ -1,0 +1,68 @@
+# Copyright 2017 Rackspace
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import mock
+import pymongo
+import pytest
+
+from mercury.common import mongo
+from tests.unit.base import MercuryCommonUnitTest
+
+
+@mock.patch('pymongo.MongoClient')
+def test_get_connection(mock_mongo_client):
+    """Test get_connection() creates a new MongoClient."""
+    mongo.get_connection('host1')
+    mock_mongo_client.assert_called_with(['host1'], replicaset=None)
+
+    mongo.get_connection(['host1', 'host2'], replica_set='replica_set_name')
+    mock_mongo_client.assert_called_with(['host1', 'host2'],
+                                         replicaset='replica_set_name')
+
+
+class MongoCollectionUnitTest(MercuryCommonUnitTest):
+    def test___init__(self):
+        """Test creation of MongoCollection."""
+        collection = mongo.MongoCollection('db_name', 'collection_name')
+
+        assert isinstance(collection.db, pymongo.database.Database)
+        assert collection.db.name == 'db_name'
+        assert isinstance(collection.collection, pymongo.collection.Collection)
+        assert collection.collection.full_name == 'db_name.collection_name'
+
+    def test___init__invalid_names(self):
+        """Test creation of MongoCollection with invalid names."""
+        with pytest.raises(pymongo.errors.InvalidName) as exc:
+            collection = mongo.MongoCollection('', 'collection_name')
+
+        with pytest.raises(pymongo.errors.InvalidName):
+            collection = mongo.MongoCollection('db_name', '')
+
+
+def test_get_collection():
+    """Test get_collection()"""
+    collection = mongo.get_collection('db_name', 'collection_name')
+
+    assert isinstance(collection, pymongo.collection.Collection)
+    assert collection.full_name == 'db_name.collection_name'
+
+
+def test_get_collection_invalid_names():
+    """Test get_collection() with invalid names."""
+    with pytest.raises(pymongo.errors.InvalidName):
+        collection = mongo.get_collection('', 'collection_name')
+
+    with pytest.raises(pymongo.errors.InvalidName):
+        collection = mongo.get_collection('db_name', '')


### PR DESCRIPTION
```
=============================================== test session starts ================================================
platform linux2 -- Python 2.7.9, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /home/vagrant/Git/mercury/src/mercury-common, inifile:
plugins: cov-2.4.0
collected 66 items


tests/unit/test_mongo.py .....


---------- coverage: platform linux2, python 2.7.9-final-0 -----------
Name                                             Stmts   Miss  Cover
--------------------------------------------------------------------
mercury/common/mongo.py                             31      0   100%

============================================ 66 passed in 0.43 seconds =============================================
```