### PR TITLE
Add unit tests for mercury.agent.capabilities

### DIFF
--- a/src/mercury-agent/mercury/agent/capabilities.py
+++ b/src/mercury-agent/mercury/agent/capabilities.py
@@ -20,8 +20,24 @@ LOG = logging.getLogger(__name__)
 runtime_capabilities = {}
 
 
-def add_capability(entry, name, description, doc=None, serial=False, num_args=None, kwarg_names=None, no_return=False,
-                   dependency_callback=None, timeout=1800, task_id_kwargs=False):
+def add_capability(entry, name, description, doc=None, serial=False,
+                   num_args=None, kwarg_names=None, no_return=False,
+                   dependency_callback=None, timeout=1800,
+                   task_id_kwargs=False):
+    """Add a new capability to the runtime capabilities.
+
+    :param entry: The new capability.
+    :param name: Name of the new capability.
+    :param description: Description of the new capability.
+    :param doc: Function docstring.
+    :param serial: Boolean indication if the task is serial.
+    :param num_args: Number of expected arguments.
+    :param kwarg_names: Named arguments.
+    :param no_return: True if the task doesn't return any value.
+    :param dependency_callback: Callback to check dependency.
+    :param timeout: Timeout for the new capability.
+    :param task_id_kwargs: Whether to put task_id in kwargs.
+    """
     LOG.info('Adding capability %s' % name)
     runtime_capabilities[name] = {
         'name': name,
@@ -38,12 +54,26 @@ def add_capability(entry, name, description, doc=None, serial=False, num_args=No
     }
 
 
-def capability(name, description, serial=False, num_args=None, kwarg_names=None, no_return=False,
+def capability(name, description, serial=False, num_args=None,
+               kwarg_names=None, no_return=False,
                dependency_callback=None, timeout=1800, task_id_kwargs=False):
+    """Decorator to add a new capability.
+
+    :param name: Name of the new capability.
+    :param description: Description of the new capability.
+    :param serial: Boolean indication if the task is serial.
+    :param num_args: Number of expected arguments.
+    :param kwarg_names: Named arguments.
+    :param no_return: True if the task doesn't return any value.
+    :param dependency_callback: Callback to check dependency.
+    :param timeout: Timeout for the new capability.
+    :param task_id_kwargs: Whether to put task_id in kwargs.
+    """
     def wrap(entry):
-        add_capability(entry, name, description, doc=entry.__doc__, serial=serial, num_args=num_args,
-                       kwarg_names=kwarg_names, no_return=no_return, dependency_callback=dependency_callback,
+        add_capability(entry, name, description, doc=entry.__doc__,
+                       serial=serial, num_args=num_args,
+                       kwarg_names=kwarg_names, no_return=no_return,
+                       dependency_callback=dependency_callback,
                        timeout=timeout, task_id_kwargs=task_id_kwargs)
         return entry
     return wrap
-

--- a/src/mercury-agent/tests/unit/test_capabilities.py
+++ b/src/mercury-agent/tests/unit/test_capabilities.py
@@ -1,0 +1,58 @@
+# Copyright 2017 Rackspace
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+"""Unit tests for mercury.agent.capabilities"""
+
+import mock
+
+from mercury.agent import capabilities
+
+
+def test_add_capability():
+    """Test add_capability()"""
+    capabilities.add_capability('c_entry',
+                                'c_name',
+                                'Capability Description')
+
+    assert 'c_name' in capabilities.runtime_capabilities
+
+    fake_capability = capabilities.runtime_capabilities['c_name']
+    assert fake_capability['name'] == 'c_name'
+    assert fake_capability['entry'] == 'c_entry'
+    assert fake_capability['description'] == 'Capability Description'
+
+    del capabilities.runtime_capabilities['c_name']
+
+
+@mock.patch('mercury.agent.capabilities.add_capability')
+def test_capability(mock_add_capability):
+    """Test @capability() decorator"""
+    @capabilities.capability('c_name', 'Capability Description', num_args=1)
+    def c_entry(x):
+        """Return input."""
+        return x
+
+    c_entry('foo')
+
+    mock_add_capability.assert_called_once_with(c_entry,
+                                                'c_name',
+                                                'Capability Description',
+                                                num_args=1,
+                                                doc="Return input.",
+                                                serial=False,
+                                                kwarg_names=None,
+                                                no_return=False,
+                                                dependency_callback=None,
+                                                timeout=1800,
+                                                task_id_kwargs=False)


### PR DESCRIPTION
```
=============================================== test session starts ================================================
platform linux2 -- Python 2.7.9, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /home/vagrant/Git/mercury/src/mercury-agent, inifile:
plugins: cov-2.4.0
collected 2 items

tests/unit/test_capabilities.py ..

---------- coverage: platform linux2, python 2.7.9-final-0 -----------
Name                            Stmts   Miss  Cover
---------------------------------------------------
mercury/agent/capabilities.py      11      0   100%


============================================= 2 passed in 0.26 seconds =============================================
```