### PR TITLE
MRC-18: On inventory registration, do not overwrite existing LLDP data.

### DIFF
--- a/scripts/start_stack.sh
+++ b/scripts/start_stack.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-WORKDIR="/home/jared/git/mercury/src"
+WORKDIR="${PWD}/src"
 SESSION="MERCURY"
-VIRTUALENV_CMD="workon python3-mercury"
+VIRTUALENV_CMD="workon ${1:-python3-mercury}"
 set -e
 
 pushd  $WORKDIR

--- a/src/mercury-inventory/mercury/inventory/hooks.py
+++ b/src/mercury-inventory/mercury/inventory/hooks.py
@@ -1,0 +1,79 @@
+# Copyright 2015 Jared Rodriguez (jared.rodriguez@rackspace.com)
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+class HookException(Exception):
+    pass
+
+
+class Hook(object):
+
+    def __init__(self, data):
+        self.data = data
+
+    async def run(self):
+        pass
+
+
+class InterfaceHook(Hook):
+
+    async def process_data(self):
+        interfaces = self.data.pop('interfaces', [])
+        for i, interface in enumerate(interfaces):
+            for key, value in interface.items():
+                new_key = 'interfaces.{}.{}'.format(i, key)
+                self.data[new_key] = value
+
+    async def run(self):
+        await self.process_data()
+
+
+class LLDPHook(Hook):
+
+    async def process_data(self):
+        try:
+            lldp = self.data.pop('lldp')
+            interface_index = lldp.pop('interface_index')
+        except KeyError:
+            raise HookException('Missing LLDP data')
+        lldp_key = 'interfaces.{}.lldp'.format(interface_index)
+        self.data[lldp_key] = lldp
+
+    async def run(self):
+        await self.process_data()
+
+
+HOOK_MAP = {
+    'interfaces': InterfaceHook,
+    'lldp': LLDPHook,
+}
+
+
+async def run_hooks(hooks, data):
+    for hook_key, hook_class in hooks.items():
+        hook = hook_class(data)
+        log.info('Running {} hook'.format(hook_key))
+        await hook.run()
+
+
+async def get_hooks_from_data(data):
+    keys = set(data.keys()) & set(HOOK_MAP.keys())
+    hooks = {key: HOOK_MAP[key] for key in keys}
+    return hooks

--- a/src/mercury-inventory/tests/unit/inventory/test_db_controller.py
+++ b/src/mercury-inventory/tests/unit/inventory/test_db_controller.py
@@ -1,9 +1,6 @@
 import unittest
 
 
-from mercury.inventory import controller
-
-
 class MercuryInventoryControllerTest(unittest.TestCase):
     """Base class for mercury-inventory unit tests."""
     def test_init(self):

--- a/src/mercury-inventory/tests/unit/inventory/test_hooks.py
+++ b/src/mercury-inventory/tests/unit/inventory/test_hooks.py
@@ -1,0 +1,95 @@
+import unittest
+
+from mock import patch
+
+from mercury.inventory import hooks
+
+
+class MercuryInventoryHookTests(unittest.TestCase):
+    """
+    General hook unit tests.
+    """
+
+    def test_get_hooks_from_data(self):
+        data = {'lldp': None, 'random': 1234}
+        hook_dict = hooks.get_hooks_from_data(data)
+        self.assertDictEqual(hook_dict, {'lldp': hooks.LLDPHook})
+
+    @patch('mercury.inventory.hooks.LLDPHook.run')
+    def test_run_hooks(self, lldp_run):
+        lldp_run.return_value = None
+        data = {'lldp': None, 'random': 1234}
+        hook_dict = hooks.get_hooks_from_data(data)
+        hooks.run_hooks(hook_dict, data)
+        lldp_run.assert_called_once()
+
+
+class MercuryInventoryLLDPHookTests(unittest.TestCase):
+    """
+    LLDP hook unit tests.
+    """
+
+    def test_lldp_hook(self):
+        data = {
+            'lldp': {
+                'switch_name': 'someswitch',
+                'switch_port': 'someport',
+                'interface_index': 0,
+            }
+        }
+
+        lldp_hook = hooks.LLDPHook(data)
+        lldp_hook.run()
+
+        expected_data = {
+            'interfaces.0.lldp': {
+                'switch_name': 'someswitch',
+                'switch_port': 'someport',
+            }
+        }
+
+        self.assertDictEqual(data, expected_data)
+
+    def test_lldp_hook_exception(self):
+        data = {
+            'lldp': {
+                'switch_name': 'someswitch',
+                'switch_port': 'someport',
+            }
+        }
+
+        lldp_hook = hooks.LLDPHook(data)
+
+        self.assertRaises(hooks.HookException, lldp_hook.run)
+
+
+class MercuryInventoryInterfaceHookTests(unittest.TestCase):
+    """
+    Interface hook unit tests.
+    """
+
+    def test_interface_hook(self):
+        data = {
+            'interfaces': [
+                {
+                    'name': 'eno1',
+                    'subdict': {'subkey': None},
+                }
+            ]
+        }
+
+        interface_hook = hooks.InterfaceHook(data)
+        interface_hook.run()
+
+        expected_data = {
+            'interfaces.0.name': 'eno1',
+            'interfaces.0.subdict': {'subkey': None},
+        }
+
+        self.assertDictEqual(data, expected_data)
+
+    def test_interface_hook_is_empty(self):
+        data = {}
+        interface_hook = hooks.InterfaceHook(data)
+        interface_hook.run()
+        self.assertEqual(data, {})


### PR DESCRIPTION
Added hook module and a modification to the start stack script. This depends on changes to the mercury agent proposed here: https://github.com/jr0d/mercury-agent/pull/3