### PR TITLE
Change package name

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -21,7 +21,7 @@ def get_version():
 
 
 setup(
-    name='mercury',
+    name='mercury-core',
     version=get_version(),
     packages=find_packages(exclude=['tests']),
     url='http://www.mercurysoft.io',


### PR DESCRIPTION
The mercury package name is taken in pypi so change the package name to mercury-core.

This change will need to be reflected in any package that is dependent on mercury or mercury-common