### PR TITLE
MRC-13: Simple http boot service.

### DIFF
--- a/scripts/start_stack.sh
+++ b/scripts/start_stack.sh
@@ -11,39 +11,34 @@ tmux -2 new-session -d -s $SESSION
 
 tmux rename-window 'Servers'
 tmux send-keys "$VIRTUALENV_CMD" C-m
-tmux send-keys "pushd mercury-inventory" C-m
-tmux send-keys "python mercury/inventory/server.py" C-m
+tmux send-keys "python mercury/inventory/service.py" C-m
 tmux send-keys "popd" C-m
 
 tmux split-window -h
 
 tmux send-keys "$VIRTUALENV_CMD" C-m
-tmux send-keys "pushd mercury-rpc" C-m
-tmux send-keys "python mercury/rpc/backend/rpc.py" C-m
+tmux send-keys "python mercury/backend/service.py" C-m
 tmux send-keys "popd" C-m
 
 tmux select-pane -t 0
 tmux split-window -v
 
 tmux send-keys "$VIRTUALENV_CMD" C-m
-tmux send-keys "pushd mercury-rpc" C-m
-tmux send-keys "python mercury/rpc/frontend/frontend.py" C-m
+tmux send-keys "python mercury/rpc/service.py" C-m
 tmux send-keys "popd" C-m
 
 tmux select-pane -t 2
 tmux split-window -v
 
 tmux send-keys "$VIRTUALENV_CMD" C-m
-tmux send-keys "pushd mercury-log" C-m
-tmux send-keys "python mercury/log_service/server.py" C-m
+tmux send-keys "python mercury/log_service/service.py" C-m
 tmux send-keys "popd" C-m
 
 tmux new-window -t $SESSION:1 -n 'Workers'
 tmux select-window -t$SESSION:1
 
 tmux send-keys "$VIRTUALENV_CMD" C-m
-tmux send-keys "pushd mercury-rpc" C-m
-tmux send-keys "python mercury/rpc/workers/rpc.py" C-m
+tmux send-keys "python mercury/rpc/workers/service.py" C-m
 tmux send-keys "popd" C-m
 
 tmux new-window -t $SESSION:2 -n 'htop' 'htop'

--- a/src/mercury/boot/app.py
+++ b/src/mercury/boot/app.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Ruben Quinones (ruben.quinones@rackspace.com)
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from flask import Flask
+
+from mercury.boot.configuration import get_boot_configuration
+from mercury.boot.urls import boot_urls
+
+app = Flask(__name__)
+
+# Add url rules
+for url, view_func in boot_urls:
+    app.add_url_rule(url, view_func=view_func, strict_slashes=False)
+
+if __name__ == '__main__':
+    configuration = get_boot_configuration()
+    app.run(host=configuration.host, port=configuration.port, debug=True)

--- a/src/mercury/boot/configuration.py
+++ b/src/mercury/boot/configuration.py
@@ -1,0 +1,63 @@
+# Copyright 2018 Ruben Quinones (ruben.quinones@rackspace.com)
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from mercury.common.configuration import MercuryConfiguration
+
+BOOT_CONFIG_FILE = 'mercury-boot.yaml'
+
+
+def options(configuration):
+    """ A single place to add program options """
+
+    configuration.add_option(
+        'host',
+        default='127.0.0.1',
+        help_string='The host address to bind to')
+
+    configuration.add_option(
+        'port',
+        default=5000,
+        help_string='The port to bind to')
+
+    configuration.add_option(
+        'file_upload_directory',
+        default='/var/www/mercury-boot',
+        help_string='The file upload directory')
+
+    configuration.add_option(
+        'default_boot_file',
+        default='pxelinux.0',
+        help_string='Default boot file path')
+
+    configuration.add_option(
+        'inventory.inventory_router',
+        '--inventory-router',
+        default='tcp://127.0.0.1:9000',
+        help_string='The inventory router url')
+
+    configuration.add_option(
+        'logging.log_file',
+        default='mercury-boot.log',
+        help_string='The log file path')
+
+    configuration.add_option(
+        'logging.level', default='DEBUG', help_string='The app log level')
+
+
+def get_boot_configuration():
+    boot_configuration = MercuryConfiguration('mercury-boot', BOOT_CONFIG_FILE)
+    options(boot_configuration)
+
+    return boot_configuration.scan_options()

--- a/src/mercury/boot/service.py
+++ b/src/mercury/boot/service.py
@@ -1,0 +1,45 @@
+# Copyright 2017 Ruben Quinones (ruben.quinones@rackspace.com)
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+
+from gevent.wsgi import WSGIServer
+
+from mercury.boot.configuration import get_boot_configuration
+from mercury.boot.app import app
+
+log = logging.getLogger(__name__)
+
+
+def main():
+    """
+    Gevent WSGI server launcher with graceful stop.
+    """
+    config = get_boot_configuration()
+    logging.basicConfig(
+        level=logging.getLevelName(config.logging.level),
+        format=config.logging.format)
+    http_server = WSGIServer((config.host, config.port), app)
+
+    try:
+        log.info('Starting gevent WSGI service')
+        http_server.serve_forever()
+    except KeyboardInterrupt:
+        log.info('Stopping gevent WSGI service')
+        http_server.stop()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/mercury/boot/urls.py
+++ b/src/mercury/boot/urls.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Ruben Quinones (ruben.quinones@rackspace.com)
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from mercury.boot.views import BootView, FileView
+
+
+boot_view = BootView.as_view('boot')
+file_view = FileView.as_view('file')
+
+
+boot_urls = [
+    # Boot url rules
+    ('/boot', boot_view),
+    ('/boot/<mac_address>', boot_view),
+    # File url rules
+    ('/file', file_view),
+    ('/file/<path>', file_view),
+]

--- a/src/mercury/boot/views.py
+++ b/src/mercury/boot/views.py
@@ -1,0 +1,150 @@
+# Copyright 2018 Ruben Quinones (ruben.quinones@rackspace.com)
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import os
+import logging
+
+from flask import request, send_file, abort, jsonify
+from flask.views import MethodView
+
+from werkzeug.utils import secure_filename
+
+from mercury.common.clients.inventory import InventoryClient
+from mercury.boot.configuration import get_boot_configuration
+
+
+log = logging.getLogger(__name__)
+configuration = get_boot_configuration()
+
+
+class BootView(MethodView):
+    """
+    Boot method view
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(BootView, self).__init__(*args, **kwargs)
+        inventory_url = configuration.inventory.inventory_router
+        self.inventory_client = InventoryClient(inventory_url)
+
+    def get(self, mac_address=None):
+        """
+        Main boot endpoint 
+
+        :param mac_address: Inventory object mac_address, default is None.
+        :return: Boot file.
+        """
+        if mac_address:
+            result = self.inventory_client.query(
+                {
+                    'interfaces.address': mac_address
+                }
+            )
+
+            try:
+                inventory = result['message']['items'][0]
+            except IndexError:
+                return abort(404)
+                
+            # Select boot file depending on inventory attributes
+            # if inventory and inventory.dmi.platform == 'Dell, Inc.':
+            #     return send_file(some_custom_dell_boot_menu)
+
+        return send_file(configuration.default_boot_file)
+
+
+
+class FileView(MethodView):
+    """ 
+    File method view 
+    """
+
+    def get(self, path=''):
+        abs_path = os.path.join(configuration.file_upload_directory, path)
+
+        if not os.path.exists(abs_path):
+            return abort(404)
+
+        if os.path.isfile(abs_path):
+            return send_file(abs_path)
+
+        files = os.listdir(abs_path)
+
+        response = []
+
+        for file_name in files:
+            file_path = os.path.join(configuration.file_upload_directory,
+                                     file_name)
+            data = self._get_file_data(file_name, file_path)
+            response.append(data)
+
+        return jsonify(response)
+
+    def post(self):
+        """
+        Upload a file to the upload directory
+        :return: None
+        """
+        upload = request.files['file']
+
+        if upload and upload.filename:
+            file_name = secure_filename(upload.filename)
+            file_path = os.path.join(configuration.file_upload_directory,
+                                     file_name)
+            upload.save(file_path)
+            data = self._get_file_data(file_name, file_path)
+
+            return jsonify(data)
+
+        return abort(400)
+
+    def delete(self, path):
+        """
+        Delete the file defined by path relative to the upload directory
+        :param path: File path
+        :return: None
+        """
+        abs_path = os.path.join(configuration.file_upload_directory, path)
+
+        if not os.path.exists(abs_path):
+            return abort(404)
+
+        if os.path.isfile(abs_path):
+            os.remove(abs_path)
+        else:
+            os.removedirs(abs_path)
+
+        return '', 204
+
+    def _get_file_data(self, file_name, file_path):
+        file_mtime = os.path.getmtime(file_path)
+        file_size = os.path.getsize(file_path)
+        file_link = 'http://{}:{}/file/{}'.format(configuration.host,
+                                                  configuration.port,
+                                                  file_name)
+        file_type = 'file'
+
+        if os.path.isdir(file_path):
+            file_type = 'directory'
+
+        data = {
+            'name': file_name,
+            'type': file_type,
+            'link': file_link,
+            'mtime': file_mtime,
+            'size': file_size,
+        }
+
+        return data

--- a/src/setup.py
+++ b/src/setup.py
@@ -39,7 +39,8 @@ setup(
         'python-box',
         'requests',
         'lxml',
-        'pystache'
+        'pystache',
+        'flask'
     ],
     entry_points={
        'console_scripts': [
@@ -48,7 +49,8 @@ setup(
            'mercury-backend = mercury.backend.service:main',
            'mercury-backend-queue = mercury.backend.queue_service.service:main',
            'mercury-backend-worker = mercury.backend.workers.service:main',
-           'mercury-log = mercury.log_service.service:main'
+           'mercury-log = mercury.log_service.service:main',
+           'mercury-boot = mercury.boot.service:main'
        ]
     }
 )


### PR DESCRIPTION
This PR adds a simple boot web service to mercury. This service can be used to PXE boot devices in network environment by adding a bootp option pointing to the boot service url. For example, this dnsmasq configuration will load the default boot file returned by the boot view:
```
interface=virbr0
bind-dynamic
dhcp-range=192.168.122.1,proxy
dhcp-boot=http://0.0.0.0/boot/
```
This default boot file can point to the boot view adding the client mac address:
```
#!ipxe 
chain http://0.0.0.0/boot/${netX/mac} ||
```
The `BootView` allows us to handle different boot options for devices depending on different criteria, for example, if a device is already registered in the mercury inventory we can then return a specific ipxe script for registered devices.

The `FileView` allows us to list the contents of the upload directory, post new files or delete existing ones. This is an example get call:

```JSON
[
{
"link": "http://127.0.0.1:5000/file/x86_64",
"mtime": 1518027124.6571739,
"name": "x86_64",
"size": 4096,
"type": "directory"
},
{
"link": "http://127.0.0.1:5000/file/pxelinux.cfg",
"mtime": 1518027124.6571739,
"name": "pxelinux.cfg",
"size": 4096,
"type": "directory"
},
{
"link": "http://127.0.0.1:5000/file/boot",
"mtime": 1518027123.6504977,
"name": "boot",
"size": 4096,
"type": "directory"
},
{
"link": "http://127.0.0.1:5000/file/pxelinux.0",
"mtime": 1518027124.6571739,
"name": "pxelinux.0",
"size": 88,
"type": "file"
},
{
"link": "http://127.0.0.1:5000/file/pkglist.x86_64.txt",
"mtime": 1518027123.733832,
"name": "pkglist.x86_64.txt",
"size": 6160,
"type": "file"
}
]
```